### PR TITLE
Updates engines to >=7.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.js"
   ],
   "engines": {
-    "node": "^8 || ^10"
+    "node": ">=7.6.0"
   },
   "scripts": {
     "lint": "eslint --cache --fix index.js",
@@ -50,5 +50,8 @@
     "arrowParens": "always",
     "singleQuote": true,
     "trailingComma": "es5"
+  },
+  "dependencies": {
+    "jest": "^24.8.0"
   }
 }


### PR DESCRIPTION
This is just a small PR to update to update the engines field in package.json to >=7.6.0. Currently this package specifies only Node 8 and 10 as available engines, which make packages that rely on this module to force npm/yarn to ignore the engines field. I tested this package in every node version since 7.6.0 (when async/await was introduced) and it works fine. Thanks for writing this, it has really helped me reduce the LOC I write to mock our AWS services.